### PR TITLE
Skip delimiter prefix tests on s3proxy localstack

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -20,6 +20,7 @@ markers =
     fails_on_s3
     fails_on_s3proxy
     fails_on_s3proxy_azureblob
+    fails_on_s3proxy_localstack
     fails_on_s3proxy_minio
     fails_on_s3proxy_nio2
     fails_with_subdomain

--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -3079,6 +3079,8 @@ def test_get_object_ifmatch_failed():
     assert status == 412
     assert error_code == 'PreconditionFailed'
 
+# localstack returns no etag with 304 responses
+@pytest.mark.fails_on_s3proxy_localstack
 @pytest.mark.fails_on_s3proxy_azureblob
 def test_get_object_ifnonematch_good():
     bucket_name = get_new_bucket()
@@ -3110,6 +3112,8 @@ def test_get_object_ifmodifiedsince_good():
     body = _get_body(response)
     assert body == 'bar'
 
+# localstack returns no etag with 304 responses
+@pytest.mark.fails_on_s3proxy_localstack
 @pytest.mark.fails_on_dbstore
 @pytest.mark.fails_on_s3proxy_azureblob
 def test_get_object_ifmodifiedsince_failed():

--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -299,6 +299,7 @@ def validate_bucket_listv2(bucket_name, prefix, delimiter, continuation_token, m
 @pytest.mark.fails_on_dbstore
 @pytest.mark.fails_on_s3proxy_azureblob
 @pytest.mark.fails_on_s3proxy_minio
+@pytest.mark.fails_on_s3proxy_localstack
 def test_bucket_list_delimiter_prefix():
     bucket_name = _create_objects(keys=['asdf', 'boo/bar', 'boo/baz/xyzzy', 'cquux/thud', 'cquux/bla'])
 
@@ -322,6 +323,7 @@ def test_bucket_list_delimiter_prefix():
 
 @pytest.mark.list_objects_v2
 @pytest.mark.fails_on_dbstore
+@pytest.mark.fails_on_s3proxy_localstack
 def test_bucket_listv2_delimiter_prefix():
     bucket_name = _create_objects(keys=['asdf', 'boo/bar', 'boo/baz/xyzzy', 'cquux/thud', 'cquux/bla'])
 
@@ -393,6 +395,7 @@ def test_bucket_listv2_delimiter_alt():
 @pytest.mark.fails_on_dbstore
 @pytest.mark.fails_on_s3proxy_azureblob
 @pytest.mark.fails_on_s3proxy_minio
+@pytest.mark.fails_on_s3proxy_localstack
 def test_bucket_list_delimiter_prefix_underscore():
     bucket_name = _create_objects(keys=['_obj1_','_under1/bar', '_under1/baz/xyzzy', '_under2/thud', '_under2/bla'])
 
@@ -415,6 +418,7 @@ def test_bucket_list_delimiter_prefix_underscore():
 
 @pytest.mark.list_objects_v2
 @pytest.mark.fails_on_dbstore
+@pytest.mark.fails_on_s3proxy_localstack
 def test_bucket_listv2_delimiter_prefix_underscore():
     bucket_name = _create_objects(keys=['_obj1_','_under1/bar', '_under1/baz/xyzzy', '_under2/thud', '_under2/bla'])
 


### PR DESCRIPTION
## Summary
Add `@pytest.mark.fails_on_s3proxy_localstack` decorator to delimiter prefix tests that fail when running against s3proxy with localstack backend. 

- The delimiter tests fail because localstack doesn't properly match AWS behavior for delimiters.
- The test_get_object* tests fail because localstack does not return etags with 304 responses which is a bug in localstack.

## Tests affected
- `test_bucket_list_delimiter_prefix`
- `test_bucket_listv2_delimiter_prefix`
- `test_bucket_list_delimiter_prefix_underscore`
- `test_bucket_listv2_delimiter_prefix_underscore`
- `test_get_object_ifnonematch_good` 
-`test_get_object_ifmodifiedsince_failed`